### PR TITLE
Prioritize longer tags

### DIFF
--- a/common/src/main/java/cc/cassian/item_descriptions/client/helpers/GenericKeys.java
+++ b/common/src/main/java/cc/cassian/item_descriptions/client/helpers/GenericKeys.java
@@ -107,7 +107,7 @@ public class GenericKeys {
             final String[] returnedKey = new String[1];
             itemStack.streamTags().forEach(itemTagKey -> {
                 String loreKey = "tag."+itemTagKey.id().toTranslationKey()+".description";
-                if (I18n.hasTranslation(loreKey)) {
+                if (I18n.hasTranslation(loreKey) && (returnedKey[0] == null || returnedKey[0].length() < loreKey.length())) {
                     returnedKey[0] = loreKey;
                 }
             });
@@ -116,7 +116,7 @@ public class GenericKeys {
                 if ((item instanceof BlockItem blockItem)) {
                     blockItem.getBlock().getDefaultState().streamTags().forEach(itemTagKey -> {
                         String loreKey = "tag."+itemTagKey.id().toTranslationKey()+".description";
-                        if (I18n.hasTranslation(loreKey)) {
+                        if (I18n.hasTranslation(loreKey) && (returnedKey[0] == null || returnedKey[0].length() < loreKey.length())) {
                             returnedKey[0] = loreKey;
                         }
                     });
@@ -129,7 +129,7 @@ public class GenericKeys {
             final String[] returnedKey = new String[1];
             state.streamTags().forEach(itemTagKey -> {
                 String loreKey = "tag."+itemTagKey.id().toTranslationKey()+".description";
-                if (I18n.hasTranslation(loreKey)) {
+                if (I18n.hasTranslation(loreKey) && (returnedKey[0] == null || returnedKey[0].length() < loreKey.length())) {
                     returnedKey[0] = loreKey;
                 }
             });
@@ -139,7 +139,7 @@ public class GenericKeys {
             final String[] returnedKey = new String[1];
             entity.getType().getRegistryEntry().streamTags().forEach(itemTagKey -> {
                 String loreKey = "tag."+itemTagKey.id().toTranslationKey()+".description";
-                if (I18n.hasTranslation(loreKey)) {
+                if (I18n.hasTranslation(loreKey) && (returnedKey[0] == null || returnedKey[0].length() < loreKey.length())) {
                     returnedKey[0] = loreKey;
                 }
             });


### PR DESCRIPTION
A cheap and incorrect fix for tags like chest boats, wooden doors, stone buttons, creeper-dropped music discs, etc.

If a tag's ID is longer, it gets prioritized over a shorter tag. chest_boats is longer than boats, and so on.

A more correct solution would be filling out a table of entry count per tag, and prioritizing tags with less entries.
This is a good bandaid though - works for all vanilla cases, and most cases by convention.