### PR TITLE
use length-based wrapping for tooltips

### DIFF
--- a/src/main/java/cc/cassian/item_descriptions/client/config/ModConfig.java
+++ b/src/main/java/cc/cassian/item_descriptions/client/config/ModConfig.java
@@ -25,7 +25,7 @@ public class ModConfig {
     public String style_color = "Gray";
     public boolean style_italics = false;
     public boolean style_bold = false;
-    public int style_length = 40;
+    public int style_length = 200;
     //Keybinds
     public boolean keybind_displayWhenControlIsHeld = true;
     public boolean keybind_displayWhenShiftIsHeld = false;

--- a/src/main/java/cc/cassian/item_descriptions/client/helpers/ModHelpers.java
+++ b/src/main/java/cc/cassian/item_descriptions/client/helpers/ModHelpers.java
@@ -387,19 +387,21 @@ public class ModHelpers {
             if (hasTranslation(loreKey)) {
                 //Check if custom wrapping should be used.
                 if (wrap && (maxLength != 0)) {
-                    //Any tooltip longer than XX characters should be shortened.
-                    while (translatedKey.length() >= maxLength) {
-                        //Find how much to shorten the tooltip by.
-                        int index = getIndex(translatedKey, maxLength);
-                        //Add a shortened tooltip.
-                        lines.add(Text.literal(translatedKey.substring(0, index)).setStyle(getStyle()));
-                        //Remove the shortened tooltip substring from the tooltip. Repeat.
-                        translatedKey = translatedKey.substring(index);
+                    //Any tooltip longer than XX pixels should be shortened.
+                    while (MinecraftClient.getInstance().textRenderer.getWidth(Text.of(translatedKey)) >= maxLength) {
+                        int lineLength = translatedKey.length();
+                        // Find where to end this line, starting from the remaining string.
+                        while (translatedKey.substring(0, lineLength).contains(" ")
+                                && MinecraftClient.getInstance().textRenderer.getWidth(Text.of(translatedKey.substring(0, lineLength))) >= maxLength) {
+                            lineLength = translatedKey.substring(0, lineLength).lastIndexOf(' ');
+                        }
+                        // Add the line.
+                        lines.add(Text.literal(translatedKey.substring(0, lineLength)).setStyle(getStyle()));
+                        // Remove the line substring from the start of the remaining string. Repeat.
+                        translatedKey = translatedKey.substring(lineLength + 1);
                     }
                 }
-                //Add the final tooltip.
-                if (!translatedKey.isBlank())
-                    lines.add(Text.literal(translatedKey).setStyle(getStyle()));
+                if (!translatedKey.isBlank()) lines.add(Text.literal(translatedKey).setStyle(getStyle()));
             }
         }
         return lines;

--- a/src/main/java/cc/cassian/item_descriptions/client/helpers/ModHelpers.java
+++ b/src/main/java/cc/cassian/item_descriptions/client/helpers/ModHelpers.java
@@ -6,6 +6,7 @@ import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.block.entity.SkullBlockEntity;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.resource.language.I18n;
 //? if >1.20.5 {

--- a/src/main/resources/assets/item_descriptions/lang/en_us.json
+++ b/src/main/resources/assets/item_descriptions/lang/en_us.json
@@ -34,7 +34,7 @@
   "config.item-descriptions.config.style_color.tooltip": "This setting changes what Minecraft colour is used for block and item tooltips, either by colour code or name",
   "config.item-descriptions.config.style_italics": "Enable Italicized Tooltips",
   "config.item-descriptions.config.style_length": "Maximum length of tooltips",
-  "config.item-descriptions.config.style_length.tooltip": "This setting changes the maximum length of tooltips. This is only enforced when ToolTipFix is not present.",
+  "config.item-descriptions.config.style_length.tooltip": "This setting changes the maximum length of tooltips (in gui pixels). This is only enforced when ToolTipFix is not present.",
   "config.item-descriptions.developer_options_title": "Developer Options",
   "config.item-descriptions.entity_descriptions_title": "Entity Descriptions",
   "config.item-descriptions.keybinds_title": "Keybinds",


### PR DESCRIPTION
This makes tooltips measure their length on-screen and wraps them that way, instead of using characters.

This reduces the instances of tooltips looking "uneven" due to varying character size.

We've also got an addition on our personal fork that splits style_length into a minimum and maximum - then adjusts based on the length of the item name - which generally makes item descs never feel like they're "ruining" the size of the tooltip. Let us know if you're interested in that - it's a bit hacky for jade/wthit because it has to use impl there, so i can just commit the in-inventory stuff if you'd prefer.