### PR TITLE
"generate missing translations" dev config

### DIFF
--- a/fabric/src/main/java/cc/cassian/item_descriptions/client/fabric/ItemDescriptionsFabricClient.java
+++ b/fabric/src/main/java/cc/cassian/item_descriptions/client/fabric/ItemDescriptionsFabricClient.java
@@ -1,9 +1,13 @@
 package cc.cassian.item_descriptions.client.fabric;
 
 import cc.cassian.item_descriptions.client.ModClient;
+import cc.cassian.item_descriptions.client.config.ModConfig;
+import cc.cassian.item_descriptions.client.helpers.ModHelpers;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.item.v1.ItemTooltipCallback;
 import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.lifecycle.v1.CommonLifecycleEvents;
+import net.minecraft.util.Identifier;
 
 import static cc.cassian.item_descriptions.client.helpers.ModHelpers.*;
 
@@ -25,6 +29,11 @@ public final class ItemDescriptionsFabricClient implements ClientModInitializer 
             createDescriptionsFromItemStack(stack, lines);
         });
 
+        if (ModConfig.get().developer_generateMissing) {
+            CommonLifecycleEvents.TAGS_LOADED.register(Identifier.of(ModClient.MOD_ID, "missing"), (manager, b) -> ModHelpers.generateMissingTranslations(
+                    manager::getOptional
+            ));
+        }
         ItemTooltipCallback.EVENT.addPhaseOrdering(Event.DEFAULT_PHASE, FABRIC_EVENT_PHASE);
         //? if >1.20.5 {
         ItemTooltipCallback.EVENT.register(FABRIC_EVENT_PHASE, (stack, context, type, lines) -> {

--- a/fabric/src/main/java/cc/cassian/item_descriptions/client/helpers/fabric/ModHelpersImpl.java
+++ b/fabric/src/main/java/cc/cassian/item_descriptions/client/helpers/fabric/ModHelpersImpl.java
@@ -1,6 +1,10 @@
 package cc.cassian.item_descriptions.client.helpers.fabric;
 
+import cc.cassian.item_descriptions.client.ModClient;
 import net.fabricmc.loader.api.FabricLoader;
+
+import java.io.File;
+import java.nio.file.Path;
 
 public class ModHelpersImpl {
     public static boolean clothConfigInstalled() {
@@ -15,4 +19,8 @@ public class ModHelpersImpl {
         return isLoaded(mod);
     }
 
+    public static File getMissingTranslationsPath() {
+        Path savePath = FabricLoader.getInstance().getGameDir().resolve("data").resolve(ModClient.MOD_ID).resolve("missing");
+        return savePath.toFile();
+    }
 }

--- a/neoforge/src/main/java/cc/cassian/item_descriptions/client/helpers/neoforge/ModHelpersImpl.java
+++ b/neoforge/src/main/java/cc/cassian/item_descriptions/client/helpers/neoforge/ModHelpersImpl.java
@@ -1,7 +1,12 @@
 package cc.cassian.item_descriptions.client.helpers.neoforge;
 
+import cc.cassian.item_descriptions.client.ModClient;
 import net.neoforged.fml.ModList;
+import net.neoforged.fml.loading.FMLPaths;
 import net.neoforged.fml.loading.LoadingModList;
+
+import java.io.File;
+import java.nio.file.Path;
 
 public class ModHelpersImpl {
     public static boolean clothConfigInstalled() {
@@ -13,5 +18,8 @@ public class ModHelpersImpl {
     public static boolean isLoadingLoaded(String mod) {
         return LoadingModList.get().getModFileById(mod) != null;
     }
-
+    public static File getMissingTranslationsPath() {
+        Path savePath = FMLPaths.getOrCreateGameRelativePath(Path.of("data").resolve(ModClient.MOD_ID).resolve("missing"));
+        return savePath.toFile();
+    }
 }

--- a/src/main/java/cc/cassian/item_descriptions/client/DescriptionKey.java
+++ b/src/main/java/cc/cassian/item_descriptions/client/DescriptionKey.java
@@ -122,8 +122,8 @@ public class DescriptionKey {
      * Convert to a translation key string suffixed with .description,
      * the primary and most specific description Item Descriptions uses.
      */
-    public String asDescriptionTranslation(String prefix) {
-        return combineDotSeperated(List.of(prefix, namespace, path, "description", suffix));
+    public String asDescriptionTranslation() {
+        return combineDotSeperated(List.of(type, namespace, path, "description", suffix));
     }
 
     /**
@@ -145,8 +145,8 @@ public class DescriptionKey {
 
     @Override
     public String toString() {
-        if (type.equals("tag") || ModHelpers.hasTranslation(asDescriptionTranslation(type))) {
-            return asDescriptionTranslation(type);
+        if (type.equals("tag") || ModHelpers.hasTranslation(asDescriptionTranslation())) {
+            return asDescriptionTranslation();
         }
         else if (ModHelpers.hasTranslation(asDescTranslation())) {
             return asDescTranslation();

--- a/src/main/java/cc/cassian/item_descriptions/client/DescriptionKey.java
+++ b/src/main/java/cc/cassian/item_descriptions/client/DescriptionKey.java
@@ -8,7 +8,6 @@ import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 
 import java.util.List;
-import java.util.Objects;
 
 public class DescriptionKey {
     private final String namespace;
@@ -91,6 +90,10 @@ public class DescriptionKey {
 
     public static DescriptionKey empty() {
         return new DescriptionKey("", "", "");
+    }
+
+    public DescriptionKey orElse(DescriptionKey other) {
+        return this.isEmpty() ? other : this;
     }
 
     public static boolean isMorePrecise(DescriptionKey currentKey, DescriptionKey newKey) {

--- a/src/main/java/cc/cassian/item_descriptions/client/config/ModConfig.java
+++ b/src/main/java/cc/cassian/item_descriptions/client/config/ModConfig.java
@@ -94,6 +94,10 @@ public class ModConfig {
      * Forces Enchantment Descriptions to be enabled, even while similar mods are installed.
      */
     public boolean developer_forceEnableEnchantmentDescriptions = false;
+    /**
+     * Creates placeholder en_us language files per-namespace in the minecraft/data/missing folder.
+     */
+    public boolean developer_generateMissing = false;
 
     // Effect Descriptions
     /**

--- a/src/main/java/cc/cassian/item_descriptions/client/helpers/ModHelpers.java
+++ b/src/main/java/cc/cassian/item_descriptions/client/helpers/ModHelpers.java
@@ -1048,7 +1048,7 @@ public class ModHelpers {
             } else if (keys.stream().noneMatch(I18n::hasTranslation)) {
                 keys.remove(description.asLoreTranslation());
                 if (value instanceof ItemStack stack) keys.remove(getModdedNameMatch(stack).asLoreTranslation()); // Ugly
-                namespaces.computeIfAbsent(key.getValue().getNamespace(), k -> new TreeMap<>()).put(description.asDescTranslation(), " ??? %s".formatted(String.join(", ", keys)));
+                namespaces.computeIfAbsent(key.getValue().getNamespace(), k -> new TreeMap<>()).put(description.asDescriptionTranslation(), " ??? %s".formatted(String.join(", ", keys)));
             }
         }
     }

--- a/src/main/java/cc/cassian/item_descriptions/client/helpers/ModHelpers.java
+++ b/src/main/java/cc/cassian/item_descriptions/client/helpers/ModHelpers.java
@@ -1,9 +1,12 @@
 package cc.cassian.item_descriptions.client.helpers;
 
 import cc.cassian.item_descriptions.client.DescriptionKey;
+import cc.cassian.item_descriptions.client.ModClient;
 import cc.cassian.item_descriptions.client.config.ModConfig;
 import cc.cassian.item_descriptions.client.helpers.compat.FastItemFramesHelpers;
 import cc.cassian.item_descriptions.client.helpers.compat.GlowcaseHelpers;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import dev.architectury.injectables.annotations.ExpectPlatform;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
@@ -13,6 +16,7 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.resource.language.I18n;
+import net.minecraft.entity.effect.StatusEffect;
 //? if >1.20.5 {
 import net.minecraft.component.ComponentType;
 import net.minecraft.component.DataComponentTypes;
@@ -25,17 +29,24 @@ import net.minecraft.nbt.NbtElement;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
 import net.minecraft.entity.decoration.ItemFrameEntity;
 import net.minecraft.entity.decoration.painting.PaintingEntity;
 import net.minecraft.entity.effect.StatusEffectInstance;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 //? if >1.21 {
+import net.minecraft.registry.Registry;
+import net.minecraft.registry.RegistryKey;
 import net.minecraft.registry.entry.RegistryEntry;
 //?} else if >1.20 {
-/*import net.minecraft.registry.Registries;
+/*import net.minecraft.registry.Registry;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.registry.Registries;
 *///?} else {
-/*import net.minecraft.util.registry.Registry;
+/*import net.minecraft.util.registry.RegistryKey;
+import net.minecraft.util.registry.Registry;
 *///?}
 import net.minecraft.text.*;
 import net.minecraft.util.Formatting;
@@ -44,13 +55,18 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import org.jetbrains.annotations.NotNull;
 
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
 import java.lang.reflect.Field;
+import java.nio.file.Path;
 import java.util.*;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
+import static cc.cassian.item_descriptions.client.ModClient.LOGGER;
 import static cc.cassian.item_descriptions.client.ModClient.MOD_ID;
-import static cc.cassian.item_descriptions.client.helpers.TagHelpers.*;
 import static net.minecraft.client.resource.language.I18n.translate;
 
 public class ModHelpers {
@@ -209,6 +225,7 @@ public class ModHelpers {
      * Create an item's lore key based off data from its Item Stack.
      */
     public static DescriptionKey findItemLoreKey(ItemStack stack) {
+        DescriptionKey key = getDescriptionKey(stack).orElse(ModConfig.get().developer_disableTagDescriptions ? TagHelpers.checkGenericTagList(stack) : DescriptionKey.empty());
         //Ensure items with Custom Model Data get a custom key instead of a vanilla one.
         //? if >1.20.5 {
             if (PolymerHelpers.getServerIdentifier(stack) != null) {
@@ -221,11 +238,9 @@ public class ModHelpers {
                 *///?} else {
                 var dataValue = data.getString(0);
                 //?}
-                DescriptionKey modelKey = getLoreKey(stack);
-                modelKey.setSuffix(".custommodeldata." + dataValue);
-                if (modelKey.hasTranslation()) {
-                    return modelKey;
-                }
+
+                key.setSafeSuffix(".custommodeldata." + dataValue);
+                return key;
             }
             else if (stack.isOf(Items.PAINTING) && hasComponent(stack, DataComponentTypes.ENTITY_DATA)) {
                 var data = Objects.requireNonNull(stack.getComponents().get(DataComponentTypes.ENTITY_DATA));
@@ -248,8 +263,7 @@ public class ModHelpers {
         /*NbtCompound s = stack.getNbt();
             if (s != null) {
                 if (s.contains("CUSTOM_MODEL_DATA", NbtElement.NUMBER_TYPE)) {
-                    var key = getLoreKey(stack);
-                    key.setSuffix("custommodeldata." + Objects.requireNonNull(s.get("CUSTOM_MODEL_DATA")));
+                    key.setSafeSuffix("custommodeldata." + Objects.requireNonNull(s.get("CUSTOM_MODEL_DATA")));
                 }
                 else if (s.contains("SkullOwner", NbtElement.STRING_TYPE)) {
                     DescriptionKey profileKey = getProfile(stack);
@@ -264,7 +278,7 @@ public class ModHelpers {
             return name;
         }
         //Find the tooltip translation key for the provided item stack.
-        return checkLoreKey(getLoreKey(stack));
+        return key;
     }
 
     public static DescriptionKey getModdedNameMatch(ItemStack stack) {
@@ -563,7 +577,7 @@ public class ModHelpers {
         /*var optionalProfileName = Objects.requireNonNull(stack.getNbt().get("CUSTOM_MODEL_DATA")).toString();
          *///?}
         if (!optionalProfileName.isEmpty()) {
-            DescriptionKey profileKey = getLoreKey(stack);
+            DescriptionKey profileKey = findItemLoreKey(stack);
             profileKey.setSuffix("profile." + optionalProfileName);
             if (profileKey.hasTranslation()) {
                 return profileKey;
@@ -685,14 +699,21 @@ public class ModHelpers {
      * Shorthand to check a block's lore key.
      */
     public static DescriptionKey findBlockLoreKey(Block block) {
-        return checkLoreKey(getLoreKey(block));
+        return checkLoreKey(getDescriptionKey(block).orElse(ModConfig.get().developer_disableTagDescriptions ? TagHelpers.checkGenericTagList(block.getDefaultState()) : DescriptionKey.empty()));
     }
 
     /**
      * Shorthand to check an entity's lore key.
      */
     public static DescriptionKey findEntityLoreKey(Entity entity) {
-        return checkLoreKey(getLoreKey(entity));
+        return checkLoreKey(getDescriptionKey(entity).orElse(ModConfig.get().developer_disableTagDescriptions ? TagHelpers.checkGenericTagList(entity.getType()) : DescriptionKey.empty()));
+    }
+
+    /**
+     * Shorthand to check an entity's lore key.
+     */
+    public static DescriptionKey findEntityTypeLoreKey(EntityType<?> entityType) {
+        return checkLoreKey(getDescriptionKey(entityType).orElse(ModConfig.get().developer_disableTagDescriptions ? TagHelpers.checkGenericTagList(entityType) : DescriptionKey.empty()));
     }
 
     /**
@@ -702,18 +723,6 @@ public class ModHelpers {
         //Check if the tooltip translation key exists. If so, use the provided tooltip.
         if (loreKey.hasTranslation()) return loreKey;
         else return DescriptionKey.empty();
-    }
-
-    /**
-     * Check if a tag exists, or if a generic one should be used.
-     */
-    private static @NotNull DescriptionKey getLoreKey(Object object) {
-        @NotNull DescriptionKey key = getDescriptionKey(object);
-        if (key.hasTranslation()) {
-            return key;
-        } else {
-            return getGenericKey(object);
-        }
     }
 
     /**
@@ -746,12 +755,27 @@ public class ModHelpers {
     public static @NotNull DescriptionKey getDescriptionKey(Object object) {
         if (object instanceof ItemStack stack) {
             return convertToLoreKey(stack.getItem().getTranslationKey());
+        } else if (object instanceof BlockState blockState) {
+            return convertToLoreKey(blockState.getBlock().getTranslationKey());
         } else if (object instanceof Block block) {
             return convertToLoreKey(block.getTranslationKey());
+        } else if (object instanceof EntityType<?> entityType) {
+            return convertToLoreKey(entityType.getTranslationKey());
         } else if (object instanceof Entity entity) {
             return convertToLoreKey(getEntityTranslationKey(entity));
+        } else if (object instanceof StatusEffect effect) {
+            return new DescriptionKey(effect.getTranslationKey());
+        } else if (object instanceof Enchantment enchantment) {
+            return getEnchantmentDescriptionKey(enchantment);
         }
         return DescriptionKey.empty();
+    }
+
+    public static DescriptionKey getEnchantmentDescriptionKey(Enchantment enchantment) {
+        //? if >1.21 {
+        return enchantment.description().getContent() instanceof TranslatableTextContent translatable ? new DescriptionKey(translatable.getKey()) : DescriptionKey.empty();
+         //?} else
+        /*return new DescriptionKey(enchantment.getTranslationKey());*/
     }
 
     /**
@@ -1007,5 +1031,53 @@ public class ModHelpers {
     @ExpectPlatform
     public static boolean isLoadingLoaded(String mod) {
         throw new AssertionError();
+    }
+
+    @ExpectPlatform
+    public static File getMissingTranslationsPath() {
+        throw new AssertionError();
+    }
+
+    private static <T> void addMissingTranslations(Registry<T> registry, Map<String, Map<String, String>> namespaces, Function<T, ?> valueTransform) {
+        for (RegistryKey<T> key : registry.getKeys()) {
+            Object value = valueTransform.apply(registry.get(key));
+            DescriptionKey description = getDescriptionKey(value);
+            List<String> keys = new ArrayList<>(TagHelpers.findAllPotentialKeys(value).stream().map(Text::getString).toList());
+            if (description.isEmpty()) {
+              LOGGER.warn("[Item Descriptions] Couldn't get lore key for {}: {}!", registry.getKey().getValue(), key.getValue());
+            } else if (keys.stream().noneMatch(I18n::hasTranslation)) {
+                keys.remove(description.asLoreTranslation());
+                if (value instanceof ItemStack stack) keys.remove(getModdedNameMatch(stack).asLoreTranslation()); // Ugly
+                namespaces.computeIfAbsent(key.getValue().getNamespace(), k -> new TreeMap<>()).put(description.asDescTranslation(), " ??? %s".formatted(String.join(", ", keys)));
+            }
+        }
+    }
+    
+    public interface RegistryGetter {
+        <E> Optional<? extends Registry<E>> get(RegistryKey<? extends Registry<? extends E>> key);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static void generateMissingTranslations(RegistryGetter registryGetter) {
+        ModClient.LOGGER.info("[Item Descriptions] Creating missing translations files");
+        File folder = getMissingTranslationsPath();
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        Map<String, Map<String, String>> namespaces = new HashMap<>();
+        addMissingTranslations((Registry<EntityType<?>>) (Object) registryGetter.get(RegistryKey.ofRegistry(Identifier.of("minecraft", "entity_type"))).orElse(null), namespaces, Function.identity());
+        addMissingTranslations((Registry<Item>) (Object) registryGetter.get(RegistryKey.ofRegistry(Identifier.of("minecraft", "item"))).orElse(null), namespaces, Item::getDefaultStack);
+        addMissingTranslations((Registry<Enchantment>) (Object) registryGetter.get(RegistryKey.ofRegistry(Identifier.of("minecraft", "enchantment"))).orElse(null), namespaces, Function.identity());
+        addMissingTranslations((Registry<Block>) (Object) registryGetter.get(RegistryKey.ofRegistry(Identifier.of("minecraft", "block"))).orElse(null), namespaces, Block::getDefaultState); // Blocks will overwrite items
+        addMissingTranslations((Registry<StatusEffect>) (Object) registryGetter.get(RegistryKey.ofRegistry(Identifier.of("minecraft", "mob_effect"))).orElse(null), namespaces, Function.identity());
+        for (Map.Entry<String, Map<String, String>> entry : namespaces.entrySet()) {
+            String namespace = entry.getKey();
+            Map<String, String> map = entry.getValue();
+            Path namespacePath = folder.toPath().resolve("assets").resolve(namespace).resolve("lang");
+            namespacePath.toFile().mkdirs();
+            try (FileWriter writer = new FileWriter(namespacePath.resolve("en_us.json").toFile())) {
+                gson.toJson(map, writer);
+            } catch (IOException e) {
+                ModClient.LOGGER.error("[Item Descriptions] Failed to write missing descriptions file", e);
+            }
+        }
     }
 }

--- a/src/main/java/cc/cassian/item_descriptions/client/helpers/TagHelpers.java
+++ b/src/main/java/cc/cassian/item_descriptions/client/helpers/TagHelpers.java
@@ -1,10 +1,12 @@
 package cc.cassian.item_descriptions.client.helpers;
 
 import cc.cassian.item_descriptions.client.DescriptionKey;
-import cc.cassian.item_descriptions.client.config.ModConfig;
 import net.minecraft.block.*;
 import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.enchantment.Enchantment;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.effect.StatusEffect;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -15,6 +17,7 @@ import net.minecraft.registry.tag.TagKey;
 /*import net.minecraft.tag.TagKey;
  *///?}
 import net.minecraft.text.Text;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,56 +31,54 @@ public class TagHelpers {
         return newKey.hasTranslation() && (currentKey[0] == null || DescriptionKey.isMorePrecise(currentKey[0], newKey));
     }
 
-    private static DescriptionKey checkGenericTagList(Object object) {
-        // If object is an item, check for Item Tags
-        if (object instanceof ItemStack itemStack) {
-            final Item item = itemStack.getItem();
-            //Temporary - Spawn Eggs do not yet have a tag.
-            if (item instanceof SpawnEggItem) {
-                return new DescriptionKey("tag", "c", "spawn_egg");
-            }
-            final DescriptionKey[] returnedKey = new DescriptionKey[1];
-            itemStack.streamTags().forEach(itemTagKey -> {
-                DescriptionKey loreKey = tagKeyToGenericKey(itemTagKey);
-                if (checkMatch(returnedKey, loreKey)) {
-                    returnedKey[0] = loreKey;
-                }
-            });
-            // If untagged, check if it is a Block Item and if a Block Tag matches.
-            if (returnedKey[0] == null) {
-                if ((item instanceof BlockItem blockItem)) {
-                    blockItem.getBlock().getDefaultState().streamTags().forEach(itemTagKey -> {
-                        DescriptionKey loreKey = tagKeyToGenericKey(itemTagKey);
-                        if (checkMatch(returnedKey, loreKey)) {
-                            returnedKey[0] = loreKey;
-                        }
-                    });
-                }
-            }
-            return returnedKey[0];
-
-            //If object is a blockstate, check it for Block tags
-        } else if (object instanceof BlockState state) {
-            final DescriptionKey[] returnedKey = new DescriptionKey[1];
-            state.streamTags().forEach(itemTagKey -> {
-                DescriptionKey loreKey = tagKeyToGenericKey(itemTagKey);
-                if (checkMatch(returnedKey, loreKey)) {
-                    returnedKey[0] = loreKey;
-                }
-            });
-            return returnedKey[0];
-        } else if (object instanceof Entity entity) {
-            final DescriptionKey[] returnedKey = new DescriptionKey[1];
-            entity.getType().getRegistryEntry().streamTags().forEach(itemTagKey -> {
-                DescriptionKey loreKey = tagKeyToGenericKey(itemTagKey);
-                if (checkMatch(returnedKey, loreKey)) {
-                    returnedKey[0] = loreKey;
-                }
-            });
-            return returnedKey[0];
-            //If no tag key matches, return empty so a string match can be found.
+    public static @NotNull DescriptionKey checkGenericTagList(ItemStack itemStack) {
+        final Item item = itemStack.getItem();
+        //Temporary - Spawn Eggs do not yet have a tag.
+        if (item instanceof SpawnEggItem) {
+            return new DescriptionKey("tag", "c", "spawn_egg");
         }
-        return DescriptionKey.empty();
+        final DescriptionKey[] returnedKey = new DescriptionKey[1];
+        itemStack.streamTags().forEach(itemTagKey -> {
+            DescriptionKey loreKey = tagKeyToGenericKey(itemTagKey);
+            if (checkMatch(returnedKey, loreKey)) {
+                returnedKey[0] = loreKey;
+            }
+        });
+        // If untagged, check if it is a Block Item and if a Block Tag matches.
+        if (returnedKey[0] == null) {
+            if ((item instanceof BlockItem blockItem)) {
+                blockItem.getBlock().getDefaultState().streamTags().forEach(itemTagKey -> {
+                    DescriptionKey loreKey = tagKeyToGenericKey(itemTagKey);
+                    if (checkMatch(returnedKey, loreKey)) {
+                        returnedKey[0] = loreKey;
+                    }
+                });
+            }
+        }
+        return Objects.requireNonNullElse(returnedKey[0], DescriptionKey.empty());
+    }
+
+    public static @NotNull DescriptionKey checkGenericTagList(BlockState state) {
+        final DescriptionKey[] returnedKey = new DescriptionKey[1];
+        state.streamTags().forEach(itemTagKey -> {
+            DescriptionKey loreKey = tagKeyToGenericKey(itemTagKey);
+            if (checkMatch(returnedKey, loreKey)) {
+                returnedKey[0] = loreKey;
+            }
+        });
+        return returnedKey[0];
+    }
+
+    public static @NotNull DescriptionKey checkGenericTagList(EntityType<?> entityType) {
+        final DescriptionKey[] returnedKey = new DescriptionKey[1];
+        entityType.getRegistryEntry().streamTags().forEach(itemTagKey -> {
+            DescriptionKey loreKey = tagKeyToGenericKey(itemTagKey);
+            if (checkMatch(returnedKey, loreKey)) {
+                returnedKey[0] = loreKey;
+            }
+        });
+        return returnedKey[0];
+        //If no tag key matches, return empty so a string match can be found.
     }
 
     private static void addSafe(ArrayList<Text> tags, DescriptionKey newAdd) {
@@ -124,11 +125,23 @@ public class TagHelpers {
                 DescriptionKey loreKey = tagKeyToGenericKey(itemTagKey);
                 addSafe(tags, loreKey);
             });
+            addSafe(tags, getDescriptionKey(state));
+        } else if (object instanceof EntityType<?> type) {
+            type.getRegistryEntry().streamTags().forEach(itemTagKey -> {
+                DescriptionKey loreKey = tagKeyToGenericKey(itemTagKey);
+                addSafe(tags, loreKey);
+            });
+            addSafe(tags, getDescriptionKey(type));
         } else if (object instanceof Entity entity) {
             entity.getType().getRegistryEntry().streamTags().forEach(itemTagKey -> {
                 DescriptionKey loreKey = tagKeyToGenericKey(itemTagKey);
                 addSafe(tags, loreKey);
             });
+            addSafe(tags, getDescriptionKey(entity));
+        } else if (object instanceof StatusEffect effect) {
+            addSafe(tags, new DescriptionKey(effect.getTranslationKey()));
+        } else if (object instanceof Enchantment enchantment) {
+            addSafe(tags, getEnchantmentDescriptionKey(enchantment));
         } else {
             tags.add(Text.empty());
         }
@@ -140,17 +153,5 @@ public class TagHelpers {
      */
     private static DescriptionKey tagKeyToGenericKey(TagKey<?> key) {
         return new DescriptionKey("tag", key.id());
-    }
-
-    public static DescriptionKey getGenericKey(Object object) {
-        if (!ModConfig.get().developer_disableTagDescriptions) {
-            //Iterate through the provided generic tag list.
-            DescriptionKey generic = checkGenericTagList(object);
-            if (generic != null) {
-                if (generic.isEmpty()) return DescriptionKey.empty();
-                else return generic;
-            }
-        }
-        return DescriptionKey.empty();
     }
 }

--- a/src/main/resources/assets/item_descriptions/lang/en_us.json
+++ b/src/main/resources/assets/item_descriptions/lang/en_us.json
@@ -16,6 +16,8 @@
   "config.item-descriptions.config.developer_showAllPotentialKeys.tooltip": "Replaces the description with a list of translation keys that can be used to match that item. Hold Alt to view their translations.",
   "config.item-descriptions.config.developer_showUntranslated": "Show lore tags on untranslated items",
   "config.item-descriptions.config.developer_showUntranslated.tooltip": "This includes items meant to have generic descriptions! Disable after testing.",
+  "config.item-descriptions.config.developer_generateMissing": "Generate missing description datapack",
+  "config.item-descriptions.config.developer_generateMissing.tooltip": "Creates placeholder en_us language files per-namespace in the minecraft/data/item-descriptions/missing folder.",
   "config.item-descriptions.config.displayAlways": "Always show Item Descriptions",
   "config.item-descriptions.config.displayAlways.tooltip": "By default, descriptions are only shown when a keybind is pressed. This is intended, but can be changed so that they are always visible.",
   "config.item-descriptions.config.displayBlockDescriptionsAlways": "Always show Block Descriptions",


### PR DESCRIPTION
generates assets in `.minecraft/data/item-descriptions/missing` corresponding to missing descriptions.

Namespaced so perfect for mod descriptions. Values are ` ??? ` with possible tags appended.

![image](https://github.com/user-attachments/assets/969fd98f-f128-44de-9e0b-37c996f83f90)

chiseled builds, but only tested on 21.5