### PR TITLE
Fix text with siblings failing to resolve when wrapping indented tooltips.

### DIFF
--- a/src/main/java/cc/cassian/item_descriptions/client/descriptions/ItemDescriptions.java
+++ b/src/main/java/cc/cassian/item_descriptions/client/descriptions/ItemDescriptions.java
@@ -8,6 +8,7 @@ import cc.cassian.item_descriptions.client.helpers.ModLists;
 import cc.cassian.item_descriptions.client.helpers.ModStyle;
 import cc.cassian.item_descriptions.client.helpers.TagHelpers;
 import cc.cassian.item_descriptions.client.helpers.compat.*;
+import net.minecraft.client.Minecraft;
 import net.minecraft.core.component.DataComponentType;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.network.chat.Component;
@@ -134,7 +135,9 @@ public class ItemDescriptions {
                 // Check if any of the tooltips' content matches the current line's content.
                 if (tooltip.stream().anyMatch(text -> text.getContents().equals(lines.get(finalI).getContents()))) {
                     var newLines = ModHelpers.createTooltip(stack.getDisplayName(), lines.get(i), ModHelpers.useInternalWrapper());
-                    if (newLines.isEmpty()) {return;}
+                    if (newLines.isEmpty()) {
+                        return;
+                    }
                     lines.set(i, newLines.getFirst());
                     if (newLines.size() > 1) {
                         lines.addAll(i + 1, newLines.subList(1, newLines.size()));

--- a/src/main/java/cc/cassian/item_descriptions/client/helpers/ModHelpers.java
+++ b/src/main/java/cc/cassian/item_descriptions/client/helpers/ModHelpers.java
@@ -314,61 +314,65 @@ public class ModHelpers {
         indentationText = null;
     }
 
+
+    private static void wrapTooltip(Component name, List<Component> lines, List<Component> keys) {
+        Minecraft.getInstance().execute(() -> wrapTooltipInternal(name, lines, keys));
+    }
+
     /**
      * An internal method for wrapping this tooltip.
      * @param lines The lines for the final tooltip.
      * @param keys Any contents that make up this text object. Obtained through {@link Component#getSiblings()}.
      */
-    private static void wrapTooltip(Component name, List<Component> lines, List<Component> keys) {
-        Minecraft.getInstance().execute(()->{
-            Font textRenderer = Minecraft.getInstance().font;
-            if (textRenderer != null && ModClient.CONFIG.style.length.value() != 0) {
-                int maxLength = Math.max(ModClient.CONFIG.style.length.value(), textRenderer.width(name));
-                for (Component originalText : keys) {
-                    // Get the text without siblings, as they're individually handled after the initial content.
-                    Component translated = originalText.plainCopy().setStyle(originalText.getStyle());
-                    if (translated.getContents() instanceof TranslatableContents translatable)
-                        translated = Component.literal(I18n.get(translatable.getKey())).setStyle(translated.getStyle());
+    private static void wrapTooltipInternal(Component name, List<Component> lines, List<Component> keys) {
 
-                    if (shouldIndent && translated.getString().isBlank() && !translated.getString().isEmpty()) {
-                        indentationText = originalText.plainCopy();
-                        // Before moving onto the next bit of text, handle any siblings of the original text.
-                        wrapTooltip(name, lines, originalText.getSiblings());
-                        shouldIndent = false;
-                        continue;
-                    }
-                    shouldIndent = false;
-                    //Any tooltip longer than XX pixels should be shortened.
-                    while (lineTextWidth + textRenderer.width(translated) >= maxLength && translated.getString().contains(" ")) {
-                        // Reset the line width.
-                        lineTextWidth = 0;
-                        // Remove the line substring from the start of the remaining string. Repeat.
-                        translated = createNewLine(lines, translated, textRenderer, maxLength);
-                    }
-                    //Add the remainder of this tooltip text.
-                    if (!translated.getString().isEmpty()) {
-                        //Any additional tooltip less than XX pixels should be merged and shortened.
-                        if (!lines.isEmpty() && lines.size() > 1 && textRenderer.width(lines.get(lines.size() - 1)) + textRenderer.width(translated) < maxLength && translated.getString().contains(" ")) {
-                            // Remove the previous text...
-                            Component oldText = lines.removeLast();
-                            // And merge it into the new one.
-                            Component newText = oldText.copy().append(translated);
-                            // Create a new line with the merged text object.
-                            createNewLine(lines, newText, textRenderer, maxLength);
-                            // Set the text line width
-                            lineTextWidth = 0;
-                        } else {
-                            // Set the text line width
-                            lineTextWidth = textRenderer.width(translated);
-                            createNewLine(lines, translated, textRenderer, maxLength);
-                        }
-                    }
+        Font textRenderer = Minecraft.getInstance().font;
+        if (textRenderer != null && ModClient.CONFIG.style.length.value() != 0) {
+            int maxLength = Math.max(ModClient.CONFIG.style.length.value(), textRenderer.width(name));
+            for (Component originalText : keys) {
+                // Get the text without siblings, as they're individually handled after the initial content.
+                Component translated = originalText.plainCopy().setStyle(originalText.getStyle());
+                if (translated.getContents() instanceof TranslatableContents translatable)
+                    translated = Component.literal(I18n.get(translatable.getKey())).setStyle(translated.getStyle());
 
+                if (shouldIndent && translated.getString().isBlank() && !translated.getString().isEmpty()) {
+                    indentationText = originalText.plainCopy();
                     // Before moving onto the next bit of text, handle any siblings of the original text.
-                    wrapTooltip(name, lines, originalText.getSiblings());
+                    wrapTooltipInternal(name, lines, originalText.getSiblings());
+                    shouldIndent = false;
+                    continue;
                 }
+                shouldIndent = false;
+                //Any tooltip longer than XX pixels should be shortened.
+                while (lineTextWidth + textRenderer.width(translated) >= maxLength && translated.getString().contains(" ")) {
+                    // Reset the line width.
+                    lineTextWidth = 0;
+                    // Remove the line substring from the start of the remaining string. Repeat.
+                    translated = createNewLine(lines, translated, textRenderer, maxLength);
+                }
+                //Add the remainder of this tooltip text.
+                if (!translated.getString().isEmpty()) {
+                    //Any additional tooltip less than XX pixels should be merged and shortened.
+                    if (!lines.isEmpty() && lines.size() > 1 && textRenderer.width(lines.get(lines.size() - 1)) + textRenderer.width(translated) < maxLength && translated.getString().contains(" ")) {
+                        // Remove the previous text...
+                        Component oldText = lines.removeLast();
+                        // And merge it into the new one.
+                        Component newText = oldText.copy().append(translated);
+                        // Create a new line with the merged text object.
+                        createNewLine(lines, newText, textRenderer, maxLength);
+                        // Set the text line width
+                        lineTextWidth = 0;
+                    } else {
+                        // Set the text line width
+                        lineTextWidth = textRenderer.width(translated);
+                        createNewLine(lines, translated, textRenderer, maxLength);
+                    }
+                }
+
+                // Before moving onto the next bit of text, handle any siblings of the original text.
+                wrapTooltipInternal(name, lines, originalText.getSiblings());
             }
-        });
+        }
     }
 
     private static Component createNewLine(List<Component> lines, Component text, Font textRenderer, int maxLength) {


### PR DESCRIPTION
Whilst testing with Enchiridion on 1.21.11, I noticed that text wrapping was cancelling out when indented descriptions were in play.

This was due to `Minecraft#execute` running every time a sibling was processed, delaying the added result to the list.
This moves the `Minecraft#execute` call to a super method so its only ever called once.

# Before and After Image
<img width="619" height="220" alt="image" src="https://github.com/user-attachments/assets/dc7b17c9-2117-416d-beef-d98114d1299f" />
